### PR TITLE
Fix: splitting '.' is error prone

### DIFF
--- a/utils/__tests__/test_file_handler.py
+++ b/utils/__tests__/test_file_handler.py
@@ -1,0 +1,12 @@
+from unittest import TestCase
+from utils import file_handler
+
+
+path_with_extension     = 'demo/common/file_name.mp3'
+path_without_extension  = 'demo/common/file_name.mp3'
+expected_result = ('demo/common/file_name', 'mp3')
+
+class TestFileHandler(TestCase):
+    def test_split_file_with_extension(self):
+        test_result = file_handler.split_file_extension(path_with_extension)
+        self.assertTupleEqual(test_result, expected_result)

--- a/utils/file_handler.py
+++ b/utils/file_handler.py
@@ -10,9 +10,21 @@ __base_url  = 'https://s3.ap-south-1.amazonaws.com/hermes-responses/'
 'icici_demo/common/dtmf_call_language.mp3'
 
 
+def split_file_extension(path):
+    """
+    default second element of the tuple is .mp3
+    :param path: str
+    :return: (str, str)
+    """
+    return (path[:-4], path[-3:]) if '.' == path[-4] else (path, '.mp3')
+
+
 def download_if_absent(url, path):
     file_data = requests.get(url)
-    file_name, ext = path.split('.')
+
+    # Assume the file to be of type .mp3 if there is no extension
+    # provided.
+    file_name, ext = split_file_extension(path)
 
     if os.path.exists(__base_path + '/' + path):
         return file_name


### PR DESCRIPTION
- The file path can contain '.' apart from the extension.
- expecting the '.' to be present at position -3, would also introduce errors in case of .FLAC files and similar.
- This is chosen because the expected format is .mp3